### PR TITLE
Allow replacements, and unix timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,6 @@ Note that this extension is for generating a static timestamp at the time of run
 
 ![Insert timestamp](images/timestamper.gif "Insert a Unix timestamp with a hotkey or from the command palette")
 
-## Known Issues
-
-Calling out known issues can help limit users opening duplicate issues against your extension.
-
-## Release Notes
-
-Users appreciate release notes as you update your extension.
-
 ### 1.0.0
 
 Initial release of Timestamper

--- a/extension.js
+++ b/extension.js
@@ -2,31 +2,45 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 
-// this method is called when your extension is activated
-// your extension is activated the very first time the command is executed
+function doReplace(editor, string)
+{
+	const selection = editor.selection;
+	editor.edit(editBuilder => {
+		editBuilder.replace(
+			new vscode.Range(selection.start, selection.end),
+			`${string}`
+		);
+	});
+}
 
 /**
+ * this method is called when your extension is activated
+ * your extension is activated the very first time the command is executed
+ *
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
 	const insertTimestamp = vscode.commands.registerCommand("extension.insertTimestamp", () => {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      return;
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+	 		 return;
 		}
 
-		const selection = editor.selection;
-		const timestamp = Date.now();
+		const timestamp = Math.round(Date.now() / 1000);
+		doReplace(editor, timestamp)
+	});
+	const insertTimestampMs = vscode.commands.registerCommand("extension.insertTimestampMs", () => {
+		const editor = vscode.window.activeTextEditor;
+		if (!editor) {
+	 		 return;
+		}
 
-		editor.edit(editBuilder => {
-			editBuilder.insert(
-				new vscode.Position(selection.active.line, selection.active.character),
-				`${timestamp}`
-			);
-		});
+		const timestamp = Date.now();
+		doReplace(editor, timestamp)
 	});
 
 	context.subscriptions.push(insertTimestamp);
+	context.subscriptions.push(insertTimestampMs);
 }
 exports.activate = activate;
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
 			{
 				"command": "extension.insertTimestamp",
 				"title": "Insert timestamp"
+			},
+			{
+				"command": "extension.insertTimestampMs",
+				"title": "Insert timestamp (Milliseconds)"
 			}
 		],
 		"keybindings": [


### PR DESCRIPTION
Hi David,

I thought I'd fix the two issues I've been having :)

 - Replace selection, rather than insert timestamp at start of selection
 - Allow both unix and millisecond based timestamp insertion